### PR TITLE
make bill-number more obviously an "as-if" stand-in quip

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # The Freedom of AI Innovation Act
 
-# California Senate Bill No. 1048
+# California Senate Bill No. 10^48
 ##### Disclaimer: A proposed, not actual senate bill.
 
 ## An act to promote and regulate the development and use of large language models and interactive AI services in the state of California.

--- a/senate-bill-freedom-of-ai-innovation-act.md
+++ b/senate-bill-freedom-of-ai-innovation-act.md
@@ -1,4 +1,4 @@
-# California Senate Bill No. 1048
+# California Senate Bill No. 10^48
 (This is a proposal for a senate bill, not an actual bill)
 
 ## An act to promote and regulate the development and use of large language models and interactive AI services in the state of California.


### PR DESCRIPTION
There's already a real "SB1028", so that's a suboptimal stand-in name for this proposal. 

But, rather than a generic "XXXX" or "TBD" or "TK", a number far outside usual bill numbering that's still evocative of both "SB1047" and the powers-of-ten discussed in frontier model debates could be used as a jokesy stand-in name: "SB 10^48". 